### PR TITLE
Improving check_sentence_ids.pl

### DIFF
--- a/check_sentence_ids.pl
+++ b/check_sentence_ids.pl
@@ -19,30 +19,49 @@ binmode(STDERR, ':utf8');
 
 my %hash;
 my $current_id = '';
-my $current_id_lineno = 0;
 my $lineno = 0;
+my $in_sentence = 0;
+my $first_sentence_line = 0;
 while(<>)
 {
     $lineno++;
     s/\r?\n$//;
-    if(m/^\#\s*sent_id\s*=\s*(.+)/)
+    if($in_sentence == 0)
     {
-        $current_id = $1;
-        $current_id_lineno = $lineno;
-    }
-    elsif(m/^\s*$/)
-    {
-        if($current_id eq '')
+        if(m/^$/)
         {
-            print STDERR ("Missing sent_id at line no. $lineno.\n");
-        }
-        elsif(exists($hash{$current_id}))
-        {
-            print STDERR ("Duplicate sent_id '$current_id' at line no. $current_id_lineno (first occurrence at line no. $hash{$current_id}).\n");
+            print STDERR ("Unwarranted empty line at line no. $lineno.\n");
         }
         else
         {
-            $hash{$current_id} = $current_id_lineno;
+            $in_sentence = 1;
+            $first_sentence_line = $lineno ;
+        }
+    }
+    if($in_sentence == 1 and m/^$/)
+    {
+        if($current_id eq '')
+        {
+            print STDERR ("Missing sent_id at sentence beginning at line no. $first_sentence_line.\n");
+        }
+        $in_sentence = 0;
+        $current_id = '';
+        $first_sentence_line = -1;
+    }
+    if(m/^\#\s*sent_id\s*=\s*(.+)/)
+    {
+        if(not($current_id eq ''))
+        {
+            print STDERR ("Multiple 'sent_id' values at sentence beginning at line no. $first_sentence_line.\n");
+        }
+        $current_id = $1;
+        if(exists($hash{$current_id}))
+        {
+            print STDERR ("Duplicate sent_id '$current_id' at line no. $lineno (first occurrence at line no. $hash{$current_id}).\n");
+        }
+        else
+        {
+            $hash{$current_id} = $lineno;
         }
     }
 }

--- a/test-cases/nonvalid/multiple-sent_id.conllu
+++ b/test-cases/nonvalid/multiple-sent_id.conllu
@@ -1,0 +1,24 @@
+# sent_id = tanl1
+# text = LONDRA .
+1	LONDRA	Londra	NOUN	SP	_	0	root	_	_
+2	.	.	PUNCT	FS	_	1	case	_	_
+
+# sent_id = tanl2
+# text = Gas dalla statua .
+1	Gas	gas	NOUN	S	Gender=Masc|Number=Sing	0	root	_	_
+2-3	dalla	_	_	_	_	_	_	_	_
+2	da	da	ADP	EA	_	1	nmod	_	_
+3	la	la	DET	RD	Gender=Fem|Number=Sing	4	det	_	_
+4	statua	statua	NOUN	S	Gender=Fem|Number=Sing	2	nmod	_	_
+5	.	.	PUNCT	FS	_	1	punct	_	_
+
+# sent_id = tanl1
+# text = Evacuata la Tate Gallery .
+# sent_id = tanl2
+# This sentence contains two sent_ids which are also repeated.
+1	Evacuata	evacuare	VERB	V	Gender=Fem|Number=Sing	3	nmod	_	_
+2	la	il	DET	RD	Gender=Fem|Number=Sing	3	det	_	_
+3	Tate	Tate	NOUN	SP	_	0	root	_	_
+4	Gallery	Gallery	NOUN	SP	_	3	fixed	_	_
+5	.	.	PUNCT	FS	_	3	punct	_	_
+

--- a/test-cases/nonvalid/no-sent_id.conllu
+++ b/test-cases/nonvalid/no-sent_id.conllu
@@ -1,0 +1,22 @@
+# sent_id = tanl1
+# text = LONDRA .
+1	LONDRA	Londra	NOUN	SP	_	0	root	_	_
+2	.	.	PUNCT	FS	_	1	case	_	_
+
+# text = Gas dalla statua .
+# this is sentence does not have a sent_id field
+1	Gas	gas	NOUN	S	Gender=Masc|Number=Sing	0	root	_	_
+2-3	dalla	_	_	_	_	_	_	_	_
+2	da	da	ADP	EA	_	1	nmod	_	_
+3	la	la	DET	RD	Gender=Fem|Number=Sing	4	det	_	_
+4	statua	statua	NOUN	S	Gender=Fem|Number=Sing	2	nmod	_	_
+5	.	.	PUNCT	FS	_	1	punct	_	_
+
+# sent_id = tanl3
+# text = Evacuata la Tate Gallery .
+1	Evacuata	evacuare	VERB	V	Gender=Fem|Number=Sing	3	nmod	_	_
+2	la	il	DET	RD	Gender=Fem|Number=Sing	3	det	_	_
+3	Tate	Tate	NOUN	SP	_	0	root	_	_
+4	Gallery	Gallery	NOUN	SP	_	3	fixed	_	_
+5	.	.	PUNCT	FS	_	3	punct	_	_
+


### PR DESCRIPTION
I'd like to suggest this modification to check_sentence_ids.pl.

- Sentences without a `sent_id` after a correct sentence (a sentence with a `sent_id`) are now reported as lacking a `sent_id`, not as having a duplicate `sent_id` (see `test-cases/nonvalid/no-sent_id.conllu`, running it under the current version and the proposed one)

- Extra empty lines are now reported explicitly, instead of reporting as duplicate `sent_id`

- Sentences with multiple `sent_id` values are now reported explicitly (see `test-cases/nonvalid/multiple-sent_id.conllu`)