### PR TITLE
(validate.py) use os.path.realpath on script directory

### DIFF
--- a/validate.py
+++ b/validate.py
@@ -15,7 +15,7 @@ import traceback
 import argparse
 
 
-THISDIR=os.path.dirname(os.path.abspath(__file__)) # The folder where this script resides.
+THISDIR=os.path.dirname(os.path.realpath(os.path.abspath(__file__))) # The folder where this script resides.
 
 # Constants for the column indices
 COLCOUNT=10


### PR DESCRIPTION
- this allows one to symlink `validate.py` to a directory within the
  `PATH` variable (it's another option to adding the whole repo to
  `PATH` if one wants to be able to call the script without having 
  to specify the whole path)