### PR TITLE
remove recursion from get_projection (avoiding Python recursion depth limit exception)

### DIFF
--- a/validate.py
+++ b/validate.py
@@ -1128,11 +1128,14 @@ def get_projection(id, tree, projection):
     Like proj() above, but works with the tree data structure. Collects node ids
     in the set called projection.
     """
-    for child in tree['children'][id]:
-        if child in projection:
-            continue # cycle is or will be reported elsewhere
-        projection.add(child)
-        get_projection(child, tree, projection)
+    nodes  = list((id,))
+    while nodes:
+        id = nodes.pop()
+        for child in tree['children'][id]:
+            if child in projection:
+                continue; # skip cycles
+            projection.add(child)
+            nodes.append(child)
     return projection
 
 def build_egraph(sentence):


### PR DESCRIPTION
I am suggesting not using recursion in `get_projection` in validation script. The recursive call cause this exception for deep trees:

```
[Line 8029 Sent ParlaMint-DK_20141008130437.seg2.7]: [L0 Format some-test] Exception caught!
Traceback (most recent call last):
  File "/home/runner/work/ParlaMint/ParlaMint/ParlaMint/Scripts/tools/validate.py", line 2293, in <module>
    validate(inp,out,args,tagsets,known_sent_ids)
  File "/home/runner/work/ParlaMint/ParlaMint/ParlaMint/Scripts/tools/validate.py", line 1902, in validate
    tree = build_tree(sentence) # level 2 test: tree is single-rooted, connected, cycle-free
  File "/home/runner/work/ParlaMint/ParlaMint/ParlaMint/Scripts/tools/validate.py", line 1117, in build_tree
    get_projection(0, tree, projection)
  File "/home/runner/work/ParlaMint/ParlaMint/ParlaMint/Scripts/tools/validate.py", line 1135, in get_projection
    get_projection(child, tree, projection)
  File "/home/runner/work/ParlaMint/ParlaMint/ParlaMint/Scripts/tools/validate.py", line 1135, in get_projection
    get_projection(child, tree, projection)
  File "/home/runner/work/ParlaMint/ParlaMint/ParlaMint/Scripts/tools/validate.py", line 1135, in get_projection
    get_projection(child, tree, projection)
  [Previous line repeated 993 more times]
  File "/home/runner/work/ParlaMint/ParlaMint/ParlaMint/Scripts/tools/validate.py", line 1134, in get_projection
    projection.add(child)
RecursionError: maximum recursion depth exceeded while calling a Python object
Format errors: 1
*** FAILED *** with 1 errors
```

I am aware that there is something odd in the sentence if it has a depth of almost 1000 nodes but it shouldn't cause script failure.