### PR TITLE
Fix eval.py so that if there is an empty node in an MWT, the empty no…

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -401,13 +401,21 @@ def load_conllu(file, path, treebank_type):
             except:
                 raise UDError("Cannot parse multi-word token ID '{}' at line {}".format(_encode(columns[ID]), line_idx))
 
-            for _ in range(start, end + 1):
+            words_expected = end - start + 1
+            words_found = 0
+            while words_found < words_expected:
                 word_line = _decode(file.readline().rstrip("\r\n"))
                 line_idx += 1
                 word_columns = word_line.split("\t")
                 if len(word_columns) != 10:
                     raise UDError("The CoNLL-U line does not contain 10 tab-separated columns at line {}: '{}'".format(line_idx, _encode(word_line)))
+                if "." in word_columns[ID]:
+                    if treebank_type.get('no_empty_nodes', False):
+                        raise UDError("The collapsed CoNLL-U line still contains empty nodes at line {}: {}".format(line_idx, _encode(line)))
+                    else:
+                        continue
                 ud.words.append(UDWord(ud.tokens[-1], word_columns, is_multiword=True))
+                words_found += 1
 
         # Basic tokens/words
         else:


### PR DESCRIPTION
Fix eval.py so that if there is an empty node in an MWT, the empty node is skipped if empty nodes are allowed in the eval.  Previously it was crashing because it would read the empty node in this loop, not reading enough of the actual words to make up the MWT.  Technically it would help error checking to check that the IDs are in the expected range in this loop as well.  https://github.com/UniversalDependencies/tools/issues/102