### PR TITLE
fix missing args parameter in validate_text_meta function

### DIFF
--- a/validate.py
+++ b/validate.py
@@ -497,7 +497,7 @@ def validate_sent_id(comments, known_ids, lcode):
 newdoc_re = re.compile(r"^#\s*newdoc(\s|$)")
 newpar_re = re.compile(r"^#\s*newpar(\s|$)")
 text_re = re.compile(r"^#\s*text\s*=\s*(.+)$")
-def validate_text_meta(comments, tree):
+def validate_text_meta(comments, tree, args):
     # Remember if SpaceAfter=No applies to the last word of the sentence.
     # This is not prohibited in general but it is prohibited at the end of a paragraph or document.
     global spaceafterno_in_effect
@@ -2831,7 +2831,7 @@ def validate(inp, out, args, tag_sets, known_sent_ids):
         if args.level > 1:
             validate_sent_id(comments, known_sent_ids, args.lang) # level 2
             if args.check_tree_text:
-                validate_text_meta(comments, sentence) # level 2
+                validate_text_meta(comments, sentence, args) # level 2
             validate_root(sentence) # level 2
             validate_ID_references(sentence) # level 2
             validate_deps(sentence) # level 2 and up


### PR DESCRIPTION
The function `validate_text_meta` was using the variable `args` ([line 611](https://github.com/UniversalDependencies/tools/blob/d3dd421eac564f5ba64b8787aa8b2d8106ae056f/validate.py#L611)) without taking it as parameter. 

This works fine when running directly the script, as the variable is inherited from outer scope, but produces an error if the `validate` function is called while imported in another module.

Therefore, I added `args` as a parameter in the `validate_text_meta` [definition](https://github.com/UniversalDependencies/tools/blob/d3dd421eac564f5ba64b8787aa8b2d8106ae056f/validate.py#L500) and [call](https://github.com/UniversalDependencies/tools/blob/d3dd421eac564f5ba64b8787aa8b2d8106ae056f/validate.py#L2834).