### PR TITLE
fix udvalidate script module

### DIFF
--- a/udtools/pyproject.toml
+++ b/udtools/pyproject.toml
@@ -37,7 +37,7 @@ Homepage = "https://universaldependencies.org/"
 Issues = "https://github.com/UniversalDependencies/tools/issues"
 
 [project.scripts]
-udvalidate = "udtools.validate:main"
+udvalidate = "udtools.validator:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]


### PR DESCRIPTION
This fixes the `udvalidate` script target module in `pyproject.toml`.

See also: https://github.com/UniversalDependencies/tools/issues/147