### PR TITLE
bugfix: import Warning

### DIFF
--- a/udtools/src/udtools/level2.py
+++ b/udtools/src/udtools/level2.py
@@ -14,11 +14,11 @@ import regex as re
 # from udtools import Validator.
 try:
     import udtools.src.udtools.utils as utils
-    from udtools.src.udtools.incident import Incident, Error, TestClass, Reference
+    from udtools.src.udtools.incident import Incident, Error, TestClass, Reference, Warning
     from udtools.src.udtools.level1 import Level1
 except ModuleNotFoundError:
     import udtools.utils as utils
-    from udtools.incident import Incident, Error, TestClass, Reference
+    from udtools.incident import Incident, Error, TestClass, Reference, Warning
     from udtools.level1 import Level1
 
 


### PR DESCRIPTION
otherwise we get
```
TypeError: Warning() takes no keyword arguments
```
errors because it interpreted as
https://docs.python.org/3/library/exceptions.html#Warning

BTW: It was a bad idea to name the class same a as a Python built-in class.
TODO: Add tests that reveal such bugs